### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits and push changes
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to resolve team reviewers
 
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -39,16 +39,11 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
       - name: Create Onetrust release branch
         id: create-release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
@@ -56,7 +51,7 @@ jobs:
           git merge origin/main
           cd OneTrustConsentFilter
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm ci
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
@@ -69,8 +64,15 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
+
+          # Get the SHA to branch from (current HEAD)
+          BASE_SHA=$(git rev-parse HEAD)
+
+          # Create branch via GitHub API
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/$branch_name" \
+            -f sha="$BASE_SHA"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -81,11 +81,20 @@ jobs:
         run: |
           cd OneTrustConsentFilter
           npm ci
-          npx standard-version -a --skip.tag
+          npx standard-version -a --skip.tag --skip.commit
+          new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
-      - name: Push new version in release branch
-        run: |
-          git push
+      - name: Create verified commit via GitHub API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.finish-release.outputs.new_version }}'
+          files: |
+            OneTrustConsentFilter/gradle.properties
+            OneTrustConsentFilter/CHANGELOG.md
 
       - name: Create pull request into main
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # GITHUB_TOKEN only needs read for checkout
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,9 +19,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits and push changes
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set Node 16
@@ -82,7 +92,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'main'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into main"
           pr_body:  ":crown: *An automated PR*"
           pr_reviewer: 'itsdebs'

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read # GITHUB_TOKEN only needs read for checkout
     name: Publish new release
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
@@ -21,6 +23,15 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
+          permission-pull-requests: write # to create and update PRs
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -36,6 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -53,8 +65,8 @@ jobs:
       - name: Create Onetrust GitHub Release & Tag
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           cd OneTrustConsentFilter
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read # GITHUB_TOKEN only needs read for checkout
     name: Publish new release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -35,13 +35,16 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          if [ "$BRANCH_NAME" = "" ]; then BRANCH_NAME=${{ github.event.inputs.version }}
+          BRANCH_NAME="$BRANCH_REF"
+          if [ "$BRANCH_NAME" = "" ]; then BRANCH_NAME="$INPUT_VERSION"
           fi
           echo "BRANCH_NAME considered: ${BRANCH_NAME}"
           VERSION=${BRANCH_NAME#release/}
-          
+
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout
@@ -55,22 +58,33 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
+      - name: Create verified tag via GitHub API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE_VERSION: ${{ steps.extract-version.outputs.release_version }}
         run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
+          # Get the SHA of the current HEAD commit
+          COMMIT_SHA=$(git rev-parse HEAD)
 
-      - name: Create Onetrust GitHub Release & Tag
+          # Create an annotated tag via GitHub API
+          gh api repos/${{ github.repository }}/git/tags \
+            -f tag="v${RELEASE_VERSION}" \
+            -f message="chore: release v${RELEASE_VERSION}" \
+            -f object="${COMMIT_SHA}" \
+            -f type="commit"
+
+          # Create the tag reference
+          gh api repos/${{ github.repository }}/git/refs \
+            -f ref="refs/tags/v${RELEASE_VERSION}" \
+            -f sha="${COMMIT_SHA}"
+
+      - name: Create GitHub Release
         id: create_release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           cd OneTrustConsentFilter
-          git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
-          git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
           DEBUG=conventional-github-releaser npx conventional-github-releaser -p angular
 
       - name: Delete release branch


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Replaces git push/tag with signed commit action and GitHub API for verified commits
- **NEW**: Simplifies draft_new_release.yml by removing unnecessary git commands and using GitHub API for branch creation

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

Reference: /Users/leonidas/.graft/cache/repos/rudderlabs/PAT_MIGRATION_AGENT_PLAN.md

### Files Changed
- .github/workflows/draft_new_release.yml
- .github/workflows/notion_pr_sync.yml
- .github/workflows/publish-new-github-release.yml

### Migration Details
| File | Token Type | Changes |
|------|------------|---------|
| notion_pr_sync.yml | GITHUB_TOKEN | Added job-level permissions (pull-requests: read), replaced PAT with GITHUB_TOKEN |
| draft_new_release.yml | GitHub App Token | Added token generation step, replaced `git push` with `ryancyq/github-signed-commit` for verified commits, **now uses GitHub API for branch creation** |
| publish-new-github-release.yml | GitHub App Token | Added token generation step, replaced `git tag && git push` with GitHub API calls for verified tags |

### Security Improvements
- Removes dependency on PAT (Personal Access Token)
- Uses least-privilege permissions at job level
- GitHub App tokens provide better audit trail and security
- **Verified commits**: Commits created via GitHub API are cryptographically signed by GitHub
- **Fixed template-injection**: Untrusted PR branch name now passed via environment variables
- **Fixed unsound-condition**: Removed redundant `${{ }}` wrapper that caused always-true condition

### Code Simplifications (Latest Commit)
Removed from draft_new_release.yml:
- ❌ `git config user.name/email` - No longer needed (signed commit uses App identity)
- ❌ `git checkout -b && git push --set-upstream` - Replaced with `gh api` to create branch via GitHub API

This makes the workflow cleaner and more secure by avoiding token-in-URL patterns.

## Test plan
- [ ] Verify notion-pr-sync workflow runs successfully on PR events
- [ ] Verify draft-new-release workflow can create release branches with verified commits
- [ ] Verify publish-new-github-release workflow can create verified tags and releases when release PRs are merged

Generated with [Claude Code](https://claude.com/claude-code)